### PR TITLE
Added continue: parameter to on_failure handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ end
 In this example, the action will be retried 5 times before the exception is raised. If the action succeeds before all
 retries, we are good and nothing wil be raised.
 
+### Specifying continue
+
+If instead of retrying the first resource after failure, you want to continue execution, specify continue true. By default continue is false and 1 retry will be attempted. retries: & continue: mutually exclude each other; if continue: is false, retries will be attempted (default 1, attention if retries = 0, no execution of the code block will take place); if continue: is true, no retries will be attempted
+
+```ruby
+meal 'breakfast' do
+  on_failure(continue: true) { notify :eat, 'meal[lunch]' }
+end
+```
+
+In this example, the action will not be retried, but execution passes to the resource notified.
+
 ### Specifying multiple exceptions
 
 Multiple exceptions classes can be specified to be caught. You can also include the options such as retries along with

--- a/debug.yml
+++ b/debug.yml
@@ -1,0 +1,18 @@
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+
+  tasks:
+    - name: Register output of uptime
+      command: uptime
+      register: reg_uptime
+
+    - name: Print registered output
+      debug:
+        var: reg_uptime
+
+    - name: Print msg if changed
+      debug:
+        msg: Command resulted in change!
+      when: reg_uptime is changed


### PR DESCRIPTION
Allows chaining of failing resources, by means of continue parameter. 
If instead of retrying the first resource after failure, you want to continue execution, specify continue true. By default continue is false and 1 retry will be attempted. The parameters retries: & continue: mutually exclude each other. If continue: is false, retries will be attempted; if continue: is true, no retries will be attempted